### PR TITLE
fix: allow last character to speak on payne engine

### DIFF
--- a/payne_engine/payne_engine.gd
+++ b/payne_engine/payne_engine.gd
@@ -340,7 +340,7 @@ func generate_xml() -> String:
 			output_xml.append("<sprite.set pos=\"%s\" anim=\"%s-idle\" />\n" % [char_pos, char_anim])
 			output_xml.append("<blip.set type=\"none\" />\n")
 
-			if dialog_blocks.size() > block_i + 1 and dialog_blocks[block_i + 1]["type"] != "newevidence":
+			if dialog_blocks.size() == block_i + 1 or dialog_blocks[block_i + 1]["type"] != "newevidence":
 				output_xml.append("<arrow.set_visible/>\n")
 				output_xml.append("<wait duration=\"2.0\"/>\n")
 


### PR DESCRIPTION
A bug existed in which the last character would not have enough time to speak on the payne engine. This could be easily tested if you set the script to just one or two messages, the last one didn't have  enough time on screen to be seen.

This PR aims to fix that